### PR TITLE
speicified left index should be kept intact.

### DIFF
--- a/veriloggen/core/module.py
+++ b/veriloggen/core/module.py
@@ -317,7 +317,7 @@ class Module(vtypes.VeriloggenNode):
         return t
         
     def Task(self, name, width=1):
-        t = task.Task(name, width)
+        t = task.Task(name)
         self.check_existing_identifier(name)        
         self.task[name] = t
         self.items.append(t)
@@ -915,7 +915,7 @@ class Generate(Module):
     def Output(self, name, width=None, length=None, signed=False, value=None):
         raise TypeError("Output port is not allowed in generate statement")
     
-    def OutputReg(self, name, width=None, length=None, signed=False, value=None):
+    def OutputReg(self, name, width=None, length=None, signed=False, value=None, initval=None):
         raise TypeError("OutputReg port is not allowed in generate statement")
     
     def Inout(self, name, width=None, length=None, signed=False, value=None):

--- a/veriloggen/core/vtypes.py
+++ b/veriloggen/core/vtypes.py
@@ -298,7 +298,7 @@ class _Numeric(VeriloggenNode):
                 left = size
             elif isinstance(left, int) and left < 0:
                 left = size - abs(left)
-                left -= 1
+            left -= 1
 
             if isinstance(left, int) and left < 0:
                 raise ValueError("Illegal slice index: left = %d" % left)

--- a/veriloggen/core/vtypes.py
+++ b/veriloggen/core/vtypes.py
@@ -292,7 +292,7 @@ class _Numeric(VeriloggenNode):
                 left = size
             elif isinstance(left, int) and left < 0:
                 left = size - abs(left)
-            left -= 1
+                left -= 1
 
             if isinstance(left, int) and left < 0:
                 raise ValueError("Illegal slice index: left = %d" % left)

--- a/veriloggen/core/vtypes.py
+++ b/veriloggen/core/vtypes.py
@@ -197,6 +197,9 @@ class VeriloggenNode(object):
     def __pos__(self):
         raise TypeError('Not allowed operation.')
     
+    def __invert__(self):
+        raise TypeError('Not allowed operation.')
+
     def __getitem__(self, r):
         raise TypeError('Not allowed operation.')
 
@@ -267,6 +270,9 @@ class _Numeric(VeriloggenNode):
     
     def __pos__(self):
         return Uplus(self)
+
+    def __invert__(self):
+        return Unot(self)
 
     def __getitem__(self, r):
         if isinstance(r, slice):
@@ -655,7 +661,7 @@ class Float(_Constant):
             raise TypeError('value of Float must be float, not %s.' % str(type(value)))
 
     def __str__(self):
-        return str(node.value)
+        return str(self.value)
 
     def get_signed(self):
         return True
@@ -670,10 +676,15 @@ class Str(_Constant):
             raise TypeError('value of Str must be str, not %s.' % str(type(value)))
 
     def __str__(self):
-        return str(node.value)
+        return str(self.value)
+
 
 #-------------------------------------------------------------------------------
 class _Operator(_Numeric):
+    def __init__(self):
+        _Numeric.__init__(self)
+        self.signed = False
+
     def get_signed(self):
         return self.signed
     
@@ -956,7 +967,7 @@ class Xnor(_BinaryOperator):
         
     @staticmethod
     def op(left, right, lwidth, rwidth):
-        width = max(lwdith, rwidth)
+        width = max(lwidth, rwidth)
         value = ~(left ^ right)
         mask = 0
         for i in range(width):
@@ -1203,7 +1214,7 @@ class Pointer(_SpecialOperator):
         return module.Assign( self.write(value) )
 
     def _type_check_var(self, var):
-        if not isinstance(var, (_Variable, Scope)):
+        if not isinstance(var, (_Variable, Scope, Pointer)):
             raise TypeError('var of Pointer must be Variable, not %s' % str(type(var)))
     
     def _add_subst(self, s):
@@ -1313,7 +1324,7 @@ class Cat(_SpecialOperator):
     def _get_module(self):
         for var in self.vars:
             if hasattr(var, '_get_module'):
-                return self.var._get_module()
+                return var._get_module()
         return None
     
     def __str__(self):
@@ -1332,7 +1343,7 @@ class Cat(_SpecialOperator):
     @staticmethod
     def op(vars, widths):
         ret = 0
-        for var, width in zip(vars, width):
+        for var, width in zip(vars, widths):
             ret = (ret << width) | var
         return ret
     

--- a/veriloggen/seq/seq.py
+++ b/veriloggen/seq/seq.py
@@ -194,7 +194,7 @@ class Seq(vtypes.VeriloggenNode):
 
         # if there is additional attribute, Else statement is separated.
         has_args = not (len(self.next_kwargs) == 0 or  # has no args
-                        (len(self.next_kwargs) == 1 and 'cond' in kwargs))  # has only 'cond'
+                        (len(self.next_kwargs) == 1 and 'cond' in self.next_kwargs))  # has only 'cond'
         if has_args:
             prev_cond = self.last_cond
             ret = self.Then()(*statement)

--- a/veriloggen/simulation/simulation.py
+++ b/veriloggen/simulation/simulation.py
@@ -47,7 +47,8 @@ def next_clock(clk):
     return ( vtypes.Event(vtypes.Posedge(clk)), vtypes.Delay(1) )
 
 def finish():
-    return Systask('finish')
+    return vtypes.Systask('finish')
+
 
 #-------------------------------------------------------------------------------
 class Simulator(object):

--- a/veriloggen/verilog/from_verilog.py
+++ b/veriloggen/verilog/from_verilog.py
@@ -7,6 +7,7 @@ import tempfile
 
 import veriloggen.core.vtypes as vtypes
 import veriloggen.core.module as module
+from veriloggen.core.module import StubModule
 import veriloggen.core.function as function
 import veriloggen.core.task as task
 
@@ -412,7 +413,7 @@ class VerilogReadVisitor(object):
         return vtypes.Uplus(self.visit(node.right))
         
     def visit_Uminus(self, node):
-        return vtype.Uminus(self.visit(node.right))
+        return vtypes.Uminus(self.visit(node.right))
         
     def visit_Ulnot(self, node):
         return vtypes.Ulnot(self.visit(node.right))
@@ -645,7 +646,7 @@ class VerilogReadVisitor(object):
     def visit_WhileStatement(self, node):
         condition = self.visit(node.cond)
         statement = to_tuple(self.visit(node.statement))
-        _while = vtypes.While(pre, condition, post)
+        _while = vtypes.While(condition)
         _while = _while(*statement)
         return _while
         


### PR DESCRIPTION
For this test
```python
from veriloggen import *


def mk_sub1():
    m = Module('sub1')
    adr = m.Input('ADR', 40)
    return m


def mk_sub2():
    m = Module('sub2')
    dat = m.Input('DAT', 30)
    return m


def mk_top():
    m = Module('top')
    adr = m.Input('ADR', 36)
    dat = m.Input('DAT', 36)

    sub1 = mk_sub1()
    sub2 = mk_sub2()

    ins1 = m.Instance(sub1, 'inst_sub1', ports=(('ADR', Cat(Int(0, 4), adr)), ) )
    #ins2 = m.Instance(sub2, 'inst_sub2', ports=(('DAT', dat[0:-1]), ) )
    ins2 = m.Instance(sub2, 'inst_sub2', ports=(('DAT', dat[0:29]), ) )

    return m

if __name__ == '__main__':
    top = mk_top()
    print(top.to_verilog())
````
I would expect the output be 
```verilog
  sub2
  inst_sub2
  (
    .DAT(DAT[29:0])  <<< old code generate [28:0]
  );
```
