### PR TITLE
Issues/54 add interval option to stypes.Counter

### DIFF
--- a/tests/extension/thread_/stream_counter/thread_stream_counter.py
+++ b/tests/extension/thread_/stream_counter/thread_stream_counter.py
@@ -25,10 +25,15 @@ def mkLed():
     ram_c = vthread.RAM(m, 'ram_c', clk, rst, datawidth, addrwidth)
 
     strm = vthread.Stream(m, 'mystream', clk, rst)
-    cnt = strm.Counter()
+    cnt1 = strm.Counter()
+    cnt2 = strm.Counter(initval=1)
+    cnt3 = strm.Counter(initval=2, size=3)
+    cnt4 = strm.Counter(initval=3, interval=3)
+    cnt5 = strm.Counter(initval=4, interval=3, size=4)
+    cnt6 = strm.Counter(initval=4, step=2, interval=2)
     a = strm.source('a')
     b = strm.source('b')
-    c = a + b + cnt
+    c = a + b - a - b + cnt1 + cnt2 + cnt3 + cnt4 + cnt5 + cnt6
     strm.sink(c, 'c')
 
     def comp_stream(size, offset):
@@ -39,14 +44,19 @@ def mkLed():
         strm.join()
 
     def comp_sequential(size, offset):
-        sum = 0
         cnt = 0
         for i in range(size):
+            cnt1 = cnt
+            cnt2 = 1 + cnt
+            cnt3 = cnt%3 + 2
+            cnt4 = (cnt//3) + 3
+            cnt5 = (cnt//3)%4 + 4
+            cnt6 = (cnt//2)*2 + 4
             a = ram_a.read(i + offset)
             b = ram_b.read(i + offset)
-            cnt += 1
-            sum = a + b + cnt
+            sum = a + b - a - b + cnt1 + cnt2 + cnt3 + cnt4 + cnt5 + cnt6
             ram_c.write(i + offset, sum)
+            cnt += 1
 
     def check(size, offset_stream, offset_seq):
         all_ok = True

--- a/tests/extension/thread_/stream_graph_ringbuffer_multi/thread_stream_graph_ringbuffer_multi.py
+++ b/tests/extension/thread_/stream_graph_ringbuffer_multi/thread_stream_graph_ringbuffer_multi.py
@@ -46,7 +46,7 @@ def mkLed():
     #b = a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8
     b = strm.AddN(a0, a1, a2, a3, a4, a5, a6, a7, a8)
 
-    strm.sink(b, 'b', when=counter > img_width + img_width + 2)
+    strm.sink(b, 'b', when=counter >= img_width + img_width + 2)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 3)

--- a/tests/extension/thread_/stream_graph_scratchpad_multi/thread_stream_graph_scratchpad_multi.py
+++ b/tests/extension/thread_/stream_graph_scratchpad_multi/thread_stream_graph_scratchpad_multi.py
@@ -29,7 +29,7 @@ def mkLed():
     counter = strm.Counter()
 
     a = strm.source('a')
-    a_addr = strm.Counter() - 1
+    a_addr = strm.Counter()
     sp = strm.Scratchpad(a, a_addr, length=128)
 
     a0 = a
@@ -49,7 +49,7 @@ def mkLed():
     #b = a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8
     b = strm.AddN(a0, a1, a2, a3, a4, a5, a6, a7, a8)
 
-    strm.sink(b, 'b', when=counter > img_width + img_width + 2)
+    strm.sink(b, 'b', when=counter >= img_width + img_width + 2)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 3)

--- a/tests/extension/thread_/stream_ringbuffer/thread_stream_ringbuffer.py
+++ b/tests/extension/thread_/stream_ringbuffer/thread_stream_ringbuffer.py
@@ -35,7 +35,7 @@ def mkLed():
 
     b = a + a_old
 
-    strm.sink(b, 'b', when=counter > img_width)
+    strm.sink(b, 'b', when=counter >= img_width)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 2)

--- a/tests/extension/thread_/stream_ringbuffer_multi/thread_stream_ringbuffer_multi.py
+++ b/tests/extension/thread_/stream_ringbuffer_multi/thread_stream_ringbuffer_multi.py
@@ -46,7 +46,7 @@ def mkLed():
     #b = a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8
     b = strm.AddN(a0, a1, a2, a3, a4, a5, a6, a7, a8)
 
-    strm.sink(b, 'b', when=counter > img_width + img_width + 2)
+    strm.sink(b, 'b', when=counter >= img_width + img_width + 2)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 3)

--- a/tests/extension/thread_/stream_ringbuffer_reuse/thread_stream_ringbuffer_reuse.py
+++ b/tests/extension/thread_/stream_ringbuffer_reuse/thread_stream_ringbuffer_reuse.py
@@ -36,7 +36,7 @@ def mkLed():
 
     b = a + a_old
 
-    strm.sink(b, 'b', when=counter > wait_num)
+    strm.sink(b, 'b', when=counter >= wait_num)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 2)

--- a/tests/extension/thread_/stream_scratchpad/thread_stream_scratchpad.py
+++ b/tests/extension/thread_/stream_scratchpad/thread_stream_scratchpad.py
@@ -29,16 +29,16 @@ def mkLed():
     counter = strm.Counter()
 
     a = strm.source('a')
-    a_addr = strm.Counter() - 1
+    a_addr = strm.Counter()
 
     sp = strm.Scratchpad(a, a_addr, length=128)
 
-    a_old_addr = strm.Counter() - img_width - 1
+    a_old_addr = strm.Counter() - img_width
     a_old = sp.read(a_old_addr)
 
     b = a + a_old
 
-    strm.sink(b, 'b', when=counter > img_width)
+    strm.sink(b, 'b', when=counter >= img_width)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 2)

--- a/tests/extension/thread_/stream_scratchpad_multi/thread_stream_scratchpad_multi.py
+++ b/tests/extension/thread_/stream_scratchpad_multi/thread_stream_scratchpad_multi.py
@@ -29,7 +29,7 @@ def mkLed():
     counter = strm.Counter()
 
     a = strm.source('a')
-    a_addr = strm.Counter() - 1
+    a_addr = strm.Counter()
     sp = strm.Scratchpad(a, a_addr, length=128)
 
     a0 = a
@@ -49,7 +49,7 @@ def mkLed():
     #b = a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8
     b = strm.AddN(a0, a1, a2, a3, a4, a5, a6, a7, a8)
 
-    strm.sink(b, 'b', when=counter > img_width + img_width + 2)
+    strm.sink(b, 'b', when=counter >= img_width + img_width + 2)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 3)

--- a/tests/extension/thread_/stream_scratchpad_when/thread_stream_scratchpad_when.py
+++ b/tests/extension/thread_/stream_scratchpad_when/thread_stream_scratchpad_when.py
@@ -29,16 +29,16 @@ def mkLed():
     counter = strm.Counter()
 
     a = strm.source('a')
-    a_addr = strm.Counter() - 1
+    a_addr = strm.Counter()
 
     sp = strm.Scratchpad(a, a_addr, when=counter <= img_width, length=128)
 
-    a_old_addr = strm.Counter() - img_width - 1
+    a_old_addr = strm.Counter() - img_width
     a_old = sp.read(a_old_addr)
 
     b = a + a_old
 
-    strm.sink(b, 'b', when=counter > img_width)
+    strm.sink(b, 'b', when=counter >= img_width)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 2)

--- a/tests/extension/thread_/stream_write_ram/thread_stream_write_ram.py
+++ b/tests/extension/thread_/stream_write_ram/thread_stream_write_ram.py
@@ -31,16 +31,16 @@ def mkLed():
     counter = strm.Counter()
 
     a = strm.source('a')
-    a_addr = strm.Counter() - 1
+    a_addr = strm.Counter()
 
-    strm.write_RAM('write_ext', a_addr, a, when=counter <= img_width)
+    strm.write_RAM('write_ext', a_addr, a, when=counter < img_width)
 
-    a_old_addr = strm.Counter() - img_width - 1
+    a_old_addr = strm.Counter() - img_width
     a_old = strm.read_RAM('read_ext', a_old_addr)
 
     b = a + a_old
 
-    strm.sink(b, 'b', when=counter > img_width)
+    strm.sink(b, 'b', when=counter >= img_width)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 2)

--- a/tests/extension/thread_/stream_write_ram_dump/thread_stream_write_ram_dump.py
+++ b/tests/extension/thread_/stream_write_ram_dump/thread_stream_write_ram_dump.py
@@ -32,16 +32,16 @@ def mkLed():
     counter = strm.Counter()
 
     a = strm.source('a')
-    a_addr = strm.Counter() - 1
+    a_addr = strm.Counter()
 
-    strm.write_RAM('write_ext', a_addr, a, when=counter <= img_width)
+    strm.write_RAM('write_ext', a_addr, a, when=counter < img_width)
 
-    a_old_addr = strm.Counter() - img_width - 1
+    a_old_addr = strm.Counter() - img_width
     a_old = strm.read_RAM('read_ext', a_old_addr)
 
     b = a + a_old
 
-    strm.sink(b, 'b', when=counter > img_width)
+    strm.sink(b, 'b', when=counter >= img_width)
 
     def comp_stream(size, offset):
         strm.set_source('a', ram_a, offset, size * 2)

--- a/veriloggen/stream/stypes.py
+++ b/veriloggen/stream/stypes.py
@@ -2445,8 +2445,6 @@ class _Accumulator(_UnaryOperator):
 
         size_data = self.size.sig_data if self.size is not None else None
         interval_data = self.interval.sig_data if self.interval is not None else None
-        # if self.size is not None and self.interval is not None:
-            # size_data *= self.interval
         initval_data = self.initval.sig_data
 
         width = self.bit_length()

--- a/veriloggen/stream/stypes.py
+++ b/veriloggen/stream/stypes.py
@@ -2583,9 +2583,9 @@ class _Accumulator(_UnaryOperator):
 class ReduceAdd(_Accumulator):
     ops = (vtypes.Plus, )
 
-    def __init__(self, right, size=None, initval=0,
+    def __init__(self, right, size=None, initval=0, interval=None,
                  enable=None, reset=None, width=32, signed=True):
-        _Accumulator.__init__(self, right, size, initval,
+        _Accumulator.__init__(self, right, size, initval, interval,
                               enable, reset, width, signed)
 
 
@@ -2633,7 +2633,7 @@ class ReduceCustom(_Accumulator):
 
 class Counter(_Accumulator):
 
-    def __init__(self, size=None, step=1, initval=0, interval=1,
+    def __init__(self, size=None, step=1, initval=0, interval=None,
                  control=None, enable=None, reset=None, width=32, signed=False):
 
         self.ops = (lambda x, y: x + step, )
@@ -2651,7 +2651,7 @@ class Counter(_Accumulator):
 class Pulse(_Accumulator):
     ops = ()
 
-    def __init__(self, size, control=None, enable=None, reset=None):
+    def __init__(self, size, control=None, enable=None, reset=None, interval=None):
 
         if control is None:
             control = 0
@@ -2661,67 +2661,67 @@ class Pulse(_Accumulator):
         width = 1
         signed = False
 
-        _Accumulator.__init__(self, control, size, initval,
+        _Accumulator.__init__(self, control, size, initval, interval,
                               enable, reset, width, signed)
         self.graph_label = 'Pulse'
 
 
-def _ReduceValid(cls, right, size, initval=0,
+def _ReduceValid(cls, right, size, initval=0, interval=None,
                  enable=None, reset=None, width=32, signed=True):
 
-    data = cls(right, size, initval,
+    data = cls(right, size, initval, interval,
                enable, reset, width, signed)
     valid = Pulse(size, right, enable, reset)
 
     return data, valid
 
 
-def ReduceAddValid(right, size, initval=0,
+def ReduceAddValid(right, size, initval=0, interval=None,
                    enable=None, reset=None, width=32, signed=True):
 
     cls = ReduceAdd
-    return _ReduceValid(cls, right, size, initval,
+    return _ReduceValid(cls, right, size, initval, interval,
                         enable, reset, width, signed)
 
 
-def ReduceSubValid(right, size, initval=0,
+def ReduceSubValid(right, size, initval=0, interval=None,
                    enable=None, reset=None, width=32, signed=True):
 
     cls = ReduceSub
-    return _ReduceValid(cls, right, size, initval,
+    return _ReduceValid(cls, right, size, initval, interval,
                         enable, reset, width, signed)
 
 
-def ReduceMulValid(right, size, initval=0,
+def ReduceMulValid(right, size, initval=0, interval=None,
                    enable=None, reset=None, width=32, signed=True):
 
     cls = ReduceMul
-    return _ReduceValid(cls, right, size, initval,
+    return _ReduceValid(cls, right, size, initval, interval,
                         enable, reset, width, signed)
 
 
-def ReduceDivValid(right, size, initval=0,
+def ReduceDivValid(right, size, initval=0, interval=None,
                    enable=None, reset=None, width=32, signed=True):
 
     cls = ReduceDiv
-    return _ReduceValid(cls, right, size, initval,
+    return _ReduceValid(cls, right, size, initval, interval,
                         enable, reset, width, signed)
 
 
-def ReduceCustomValid(ops, right, size, initval=0,
+def ReduceCustomValid(ops, right, size, initval=0, interval=None,
                       enable=None, reset=None, width=32, signed=True):
 
-    data = ReduceCustom(ops, right, size, initval,
+    data = ReduceCustom(ops, right, size, initval, interval,
                         enable, reset, width, signed)
     valid = Pulse(size, right, enable, reset)
 
     return data, valid
 
 
-def CounterValid(size, step=1, initval=None,
+def CounterValid(size, step=1, initval=0, interval=None,
                  control=None, enable=None, reset=None, width=32, signed=False):
 
-    data = Counter(size, step, initval,
+    data = Counter(size, step, initval, interval,
                    control, enable, reset, width, signed)
     valid = Pulse(size, control, enable, reset)
 


### PR DESCRIPTION
 - Add update `interval` option to stypes.Counter
    -  add `interval` option argument  to stypes._Accumulator and its derived class.
    - The expected value cannot be obtained by setting the update interval with nesting a counter with the enable argument of other counter.
```python
main = vthread.Stream(m, 'main', clk, rst)
xcounter = main.Counter(initval=0, size=4) #0,1,2,3..
ycounter = main.Counter(initval=1, enable=(xcounter == 3))#0,0,0,0,1,1,1,1..

Step: 0 1 2 3 4 5 6 7
x   : x x 0 1 2 3 4 5
y   : x x x x 0 0 0 1 #we want four zero!
```
The processing of `xcounter==3` takes 2 clock cycles, so counter _y_ is reset at _3rd clock cycle_, 2 cycles after the xcounter reset. And at _4th clock cycle_, `xcounter==3` holds, after two cycle, the value of _y_ counter is updated to 1.

This update can define counter with `interval` as following.
```python
cnt1 = strm.Counter()
cnt2 = strm.Counter(initval=1)
cnt3 = strm.Counter(initval=2, size=3)
cnt4 = strm.Counter(initval=3, interval=3)
cnt5 = strm.Counter(initval=4, interval=3, size=4)
cnt6 = strm.Counter(initval=4, step=2, interval=2)
step,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33
cnt1,x,x,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31
cnt2,x,x,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32
cnt3,x,x,2,3,4,2,3,4,2,3,4,2,3,4,2,3,4,2,3,4,2,3,4,2,3,4,2,3,4,2,3,4,2,3
cnt4,x,x,3,3,3,4,4,4,5,5,5,6,6,6,7,7,7,8,8,8,9,9,9,10,10,10,11,11,11,12,12,12,13,13
cnt5,x,x,4,4,4,5,5,5,6,6,6,7,7,7,4,4,4,5,5,5,6,6,6,7,7,7,4,4,4,5,5,5,6,6
cnt6,x,x,4,4,6,6,8,8,10,10,12,12,14,14,16,16,18,18,20,20,22,22,24,24,26,26,28,28,30,30,32,32,34,34
```

- Fixed the problem that the counter initial value is 1 larger than the expected value when `size` is not specified.
  - the initial counter value with no option arguments is changed to zero. This modification was applied to some tests. https://github.com/PyHDI/veriloggen/commit/c7a4d8a37b26be919acf9f4b238f9f741399517e

