### PR TITLE
modify bug in readRAM when latency = 2

### DIFF
--- a/veriloggen/stream/stypes.py
+++ b/veriloggen/stream/stypes.py
@@ -3505,6 +3505,7 @@ class ReadRAM(_SpecialOperator):
 
         if self.latency == 2:
             data = m.Wire(self.name('data'), datawidth, signed=signed)
+            data.assign(rdata)
             self.sig_data = data
 
         elif self.latency == 3:


### PR DESCRIPTION
Fixed a bug that data port is not connected to wire when latency = 2 in read_RAM.