### PR TITLE
add stypes.LineBuffer

### DIFF
--- a/tests/extension/thread_/stream_linebuffer2d/Makefile
+++ b/tests/extension/thread_/stream_linebuffer2d/Makefile
@@ -1,0 +1,29 @@
+TARGET=$(shell ls *.py | grep -v test | grep -v parsetab.py)
+ARGS=
+
+PYTHON=python3
+#PYTHON=python
+#OPT=-m pdb
+#OPT=-m cProfile -s time
+#OPT=-m cProfile -o profile.rslt
+
+.PHONY: all
+all: test
+
+.PHONY: run
+run:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS)
+
+.PHONY: test
+test:
+	$(PYTHON) -m pytest -vv
+
+.PHONY: check
+check:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS) > tmp.v
+	iverilog -tnull -Wall tmp.v
+	rm -f tmp.v
+
+.PHONY: clean
+clean:
+	rm -rf *.pyc __pycache__ parsetab.py .cache *.out *.png *.dot tmp.v uut.vcd

--- a/tests/extension/thread_/stream_linebuffer2d/test_thread_stream_linebuffer2d.py
+++ b/tests/extension/thread_/stream_linebuffer2d/test_thread_stream_linebuffer2d.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import veriloggen
+import thread_stream_linebuffer2d
+
+
+def test(request):
+    veriloggen.reset()
+
+    simtype = request.config.getoption('--sim')
+
+    rslt = thread_stream_linebuffer2d.run(filename=None, simtype=simtype,
+                                    outputfile=os.path.splitext(os.path.basename(__file__))[0] + '.out')
+
+    verify_rslt = rslt.splitlines()[-1]
+    assert(verify_rslt == '# verify: PASSED')

--- a/tests/extension/thread_/stream_linebuffer2d/thread_stream_linebuffer2d.py
+++ b/tests/extension/thread_/stream_linebuffer2d/thread_stream_linebuffer2d.py
@@ -1,0 +1,181 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import sys
+import os
+import functools
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))))
+
+from veriloggen import *
+import veriloggen.thread as vthread
+import veriloggen.types.axi as axi
+
+
+def mkLed():
+    m = Module('blinkled')
+    clk = m.Input('CLK')
+    rst = m.Input('RST')
+
+    datawidth = 32
+    addrwidth = 10
+    saxi_length = 4
+    myaxi = vthread.AXIM(m, 'myaxi', clk, rst, datawidth)
+    saxi = vthread.AXISLiteRegister(m, 'saxi', clk, rst, datawidth=datawidth, length=saxi_length)
+    ram_src = vthread.RAM(m, 'ram_src', clk, rst, datawidth, addrwidth)
+    ram_dummy_src = vthread.RAM(m, 'ram_dummy_src', clk, rst, datawidth, addrwidth)
+    ram_dst = vthread.RAM(m, 'ram_dst', clk, rst, datawidth, addrwidth)
+
+    strm = vthread.Stream(m, 'mystream', clk, rst)
+    dummy_src = strm.source('dummy_src')
+    x = strm.Counter(initval=0, size=8)
+    y = strm.Counter(initval=0, size=8, enable=(x==7))
+    
+    shift_cond = ((x&1 == 0) & (y&1 == 0))
+    rotate_cond = ((shift_cond == 0) & (x&1 == 0))
+    read_cond = shift_cond
+    addrcounter = strm.Counter(initval=0, enable=read_cond)
+    src = strm.read_RAM('ram_src', addr=addrcounter, when=read_cond, datawidth=datawidth)
+    counter = strm.Counter(initval=0)
+    width = strm.constant('width')
+    height = strm.constant('height')
+
+    linebuf = strm.LineBuffer(shape=(1, 1), memlens=[4], head_initvals=[0], tail_initvals=[3], data=src, shift_cond=shift_cond, rotate_conds = [rotate_cond])
+    dst = linebuf.get_window(0)
+    strm.sink(dst, 'dst')
+    
+    def comp_stream(width, height, offset):
+        strm.set_source('dummy_src', ram_dummy_src, offset, width * height * 2 * 2)
+        strm.set_read_RAM('ram_src', ram_src)
+        strm.set_sink('dst', ram_dst, offset, width * height)
+        strm.set_constant('width', width)
+        strm.set_constant('height', height)
+        strm.run()
+        strm.join()
+
+    def comp_sequential(width, height, offset):
+        for y in range(height*2):
+            for x in range(width*2):
+                src_i = x//2 + (y//2) * width
+                dst_i = x + y * width * 2
+                val = ram_src.read(offset + src_i)
+                ram_dst.write(offset + dst_i, val)
+            
+    def check(offset_stream, offset_seq, size):
+        all_ok = True
+        for i in range(size):
+            st = ram_dst.read(offset_stream + i)
+            sq = ram_dst.read(offset_seq + i)
+            if vthread.verilog.NotEql(st, sq):
+                all_ok = False
+            # print(st, sq)
+        if all_ok:
+            print('# verify: PASSED')
+        else:
+            print('# verify: FAILED')
+
+    def comp():
+        saxi.write(addr=1, value=0)
+        saxi.wait_flag(0, value=1, resetvalue=0)
+        width = saxi.read(2)
+        height = saxi.read(3)
+        size = width * height
+
+        offset = 0
+        myaxi.dma_read(ram_src, offset, 0, size)
+        comp_stream(width, height, offset)
+        myaxi.dma_write(ram_dst, offset, 1024, size)
+
+        offset = size
+        myaxi.dma_read(ram_src, offset, 0, size)
+        comp_sequential(width, height, offset)
+        myaxi.dma_write(ram_dst, offset, 2*1024, size)
+
+        check(0, offset, size)
+        saxi.write(addr=1, value=1)
+
+    th = vthread.Thread(m, 'th_comp', clk, rst, comp)
+    fsm = th.start()
+    strm.draw_graph(filename='strm.png')
+    return m
+
+
+def mkTest(memimg_name=None):
+    m = Module('test')
+
+    # target instance
+    led = mkLed()
+
+    # copy paras and ports
+    params = m.copy_params(led)
+    ports = m.copy_sim_ports(led)
+
+    clk = ports['CLK']
+    rst = ports['RST']
+
+    memory = axi.AxiMemoryModel(m, 'memory', clk, rst, memimg_name=memimg_name)
+    memory.connect(ports, 'myaxi')
+    maxi = vthread.AXIMLite(m, 'maxi', clk, rst, noio=True)
+    maxi.connect(ports, 'saxi')
+
+    def ctrl():
+        width, height = [4, 4]
+
+        awaddr = 2 * 4
+        maxi.write(awaddr, width)
+
+        awaddr = 3 * 4
+        maxi.write(awaddr, height)
+
+        awaddr = 0 * 4
+        maxi.write(awaddr, 1)
+
+        araddr = 1 * 4
+        v = maxi.read(araddr)
+        while v == 0:
+            v = maxi.read(araddr)
+        vthread.finish()
+
+    th = vthread.Thread(m, 'th_ctrl', clk, rst, ctrl)
+    fsm = th.start()
+
+    uut = m.Instance(led, 'uut',
+                     params=m.connect_params(led),
+                     ports=m.connect_ports(led))
+
+    #simulation.setup_waveform(m, uut)
+    simulation.setup_clock(m, clk, hperiod=5)
+    init = simulation.setup_reset(m, rst, m.make_reset(), period=100)
+
+    init.add(
+        Delay(1000000),
+        Systask('finish'),
+    )
+
+    return m
+
+
+def run(filename='tmp.v', simtype='iverilog', outputfile=None):
+
+    if outputfile is None:
+        outputfile = os.path.splitext(os.path.basename(__file__))[0] + '.out'
+
+    memimg_name = 'memimg_' + outputfile
+
+    test = mkTest(memimg_name=memimg_name)
+
+    if filename is not None:
+        test.to_verilog(filename)
+
+    sim = simulation.Simulator(test, sim=simtype)
+    rslt = sim.run(outputfile=outputfile)
+    lines = rslt.splitlines()
+    if simtype == 'verilator' and lines[-1].startswith('-'):
+        rslt = '\n'.join(lines[:-1])
+    return rslt
+
+
+if __name__ == '__main__':
+    rslt = run(filename='tmp.v')
+    print(rslt)

--- a/tests/extension/thread_/stream_linebuffer2d_2/Makefile
+++ b/tests/extension/thread_/stream_linebuffer2d_2/Makefile
@@ -1,0 +1,29 @@
+TARGET=$(shell ls *.py | grep -v test | grep -v parsetab.py)
+ARGS=
+
+PYTHON=python3
+#PYTHON=python
+#OPT=-m pdb
+#OPT=-m cProfile -s time
+#OPT=-m cProfile -o profile.rslt
+
+.PHONY: all
+all: test
+
+.PHONY: run
+run:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS)
+
+.PHONY: test
+test:
+	$(PYTHON) -m pytest -vv
+
+.PHONY: check
+check:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS) > tmp.v
+	iverilog -tnull -Wall tmp.v
+	rm -f tmp.v
+
+.PHONY: clean
+clean:
+	rm -rf *.pyc __pycache__ parsetab.py .cache *.out *.png *.dot tmp.v uut.vcd

--- a/tests/extension/thread_/stream_linebuffer2d_2/test_thread_stream_linebuffer2d_2.py
+++ b/tests/extension/thread_/stream_linebuffer2d_2/test_thread_stream_linebuffer2d_2.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import veriloggen
+import thread_stream_linebuffer2d_2
+
+
+def test(request):
+    veriloggen.reset()
+
+    simtype = request.config.getoption('--sim')
+
+    rslt = thread_stream_linebuffer2d_2.run(filename=None, simtype=simtype,
+                                    outputfile=os.path.splitext(os.path.basename(__file__))[0] + '.out')
+
+    verify_rslt = rslt.splitlines()[-1]
+    assert(verify_rslt == '# verify: PASSED')

--- a/tests/extension/thread_/stream_linebuffer2d_2/thread_stream_linebuffer2d_2.py
+++ b/tests/extension/thread_/stream_linebuffer2d_2/thread_stream_linebuffer2d_2.py
@@ -1,0 +1,223 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import sys
+import os
+import functools
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))))
+
+from veriloggen import *
+import veriloggen.thread as vthread
+import veriloggen.types.axi as axi
+
+
+def mkLed():
+    m = Module('blinkled')
+    clk = m.Input('CLK')
+    rst = m.Input('RST')
+
+    datawidth = 32
+    addrwidth = 10
+    saxi_length = 4
+    myaxi = vthread.AXIM(m, 'myaxi', clk, rst, datawidth)
+    saxi = vthread.AXISLiteRegister(m, 'saxi', clk, rst, datawidth=datawidth, length=saxi_length)
+    ram_src = vthread.RAM(m, 'ram_src', clk, rst, datawidth, addrwidth)
+    ram_dst = vthread.RAM(m, 'ram_dst', clk, rst, datawidth, addrwidth)
+
+    strm = vthread.Stream(m, 'mystream', clk, rst)
+    src = strm.source('src')
+    counter = strm.Counter(initval=0)
+    width = strm.constant('width')
+    height = strm.constant('height')
+    # shift x10
+    # rotate x10
+    # shift, rotate x44
+    shift_cond = strm.Or((counter < 10), ((counter >= 20) & (counter&1 == 0)))
+    rotate_cond = strm.Or(((counter >= 10) & (counter < 20)), ((counter >= 20) & (counter&1 == 1)))
+    linebuf = strm.LineBuffer(shape=(3, 3), memlens=[4],  data=src, head_initvals=[3], tail_initvals=[0],shift_cond=shift_cond, rotate_conds=[rotate_cond])
+    window = [None] * 9
+    for y in range(3):
+        for x in range(3):
+            window[y * 3 + x] = linebuf.get_window(y * 3 + x)
+    dst = strm.AddN(*window)
+    strm.sink(dst, 'dst')
+
+    #for sequential
+    ram_bufs = [vthread.RAM(m, 'ram_buf' + str(i), clk, rst, datawidth, addrwidth) for i in range(3)]
+
+    def comp_stream(width, height, offset):
+        strm.set_source('src', ram_src, offset, width * height)
+        strm.set_sink('dst', ram_dst, offset, width * height)
+        strm.set_constant('width', width)
+        strm.set_constant('height', height)
+        strm.run()
+        strm.join()
+
+    def comp_sequential(width, height, offset):
+        tail = 0
+        head = 3
+        window_0 = window_1 = window_2 = 0
+        window_3 = window_4 = window_5 = 0
+        window_6 = window_7 = window_8 = 0
+
+        #initialize shift memory
+        for i in range(4):
+            ram_bufs[2].write(i, 0)
+            ram_bufs[1].write(i, 0)
+            ram_bufs[0].write(i, 0)
+
+        for i in range(width * height):
+            src = ram_src.read(offset + i)
+            shift = ((i < 10) or ((i >= 20) and (i&1 == 0)))
+            rotate = (((i >= 10) and (i < 20)) or ((i >= 20) and (i&1 == 1)))
+            if shift:
+                ram_bufs[2].write(tail, window_8)
+                window_8 = window_7
+                window_7 = window_6
+                window_6 = ram_bufs[1].read(head)
+                ram_bufs[1].write(tail, window_5)
+                window_5 = window_4
+                window_4 = window_3
+                window_3 = ram_bufs[0].read(head)
+                ram_bufs[0].write(tail, window_2)
+                window_2 = window_1
+                window_1 = window_0
+                window_0 = src
+                head = head + 1 if head < 3 else 0
+                tail = tail + 1 if tail < 3 else 0
+            elif rotate:
+                ram_bufs[2].write(tail, window_8)
+                window_8 = window_7
+                window_7 = window_6
+                window_6 = ram_bufs[2].read(head)
+                ram_bufs[1].write(tail, window_5)
+                window_5 = window_4
+                window_4 = window_3
+                window_3 = ram_bufs[1].read(head)
+                ram_bufs[0].write(tail, window_2)
+                window_2 = window_1
+                window_1 = window_0
+                window_0 = ram_bufs[0].read(head)
+                head = head + 1 if head < 3 else 0
+                tail = tail + 1 if tail < 3 else 0
+            sum = window_0 + window_1 +  window_2 +  window_3 +  window_4 +  window_5 +  window_6 +  window_7 + window_8
+            ram_dst.write(offset + i, sum)
+            
+    def check(offset_stream, offset_seq, size):
+        all_ok = True
+        for i in range(size):
+            st = ram_dst.read(offset_stream + i)
+            sq = ram_dst.read(offset_seq + i)
+            if vthread.verilog.NotEql(st, sq):
+                all_ok = False
+        if all_ok:
+            print('# verify: PASSED')
+        else:
+            print('# verify: FAILED')
+
+    def comp():
+        saxi.write(addr=1, value=0)
+        saxi.wait_flag(0, value=1, resetvalue=0)
+        width = saxi.read(2)
+        height = saxi.read(3)
+        size = width * height
+
+        offset = 0
+        myaxi.dma_read(ram_src, offset, 0, size)
+        comp_stream(width, height, offset)
+        myaxi.dma_write(ram_dst, offset, 1024, size)
+
+        offset = size
+        myaxi.dma_read(ram_src, offset, 0, size)
+        comp_sequential(width, height, offset)
+        myaxi.dma_write(ram_dst, offset, 2*1024, size)
+
+        check(0, offset, size)
+        saxi.write(addr=1, value=1)
+
+    th = vthread.Thread(m, 'th_comp', clk, rst, comp)
+    fsm = th.start()
+    strm.draw_graph(filename='strm.png')
+    return m
+
+
+def mkTest(memimg_name=None):
+    m = Module('test')
+
+    # target instance
+    led = mkLed()
+
+    # copy paras and ports
+    params = m.copy_params(led)
+    ports = m.copy_sim_ports(led)
+
+    clk = ports['CLK']
+    rst = ports['RST']
+
+    memory = axi.AxiMemoryModel(m, 'memory', clk, rst, memimg_name=memimg_name)
+    memory.connect(ports, 'myaxi')
+    maxi = vthread.AXIMLite(m, 'maxi', clk, rst, noio=True)
+    maxi.connect(ports, 'saxi')
+
+    def ctrl():
+        width, height = [8, 8]
+
+        awaddr = 2 * 4
+        maxi.write(awaddr, width)
+
+        awaddr = 3 * 4
+        maxi.write(awaddr, height)
+
+        awaddr = 0 * 4
+        maxi.write(awaddr, 1)
+
+        araddr = 1 * 4
+        v = maxi.read(araddr)
+        while v == 0:
+            v = maxi.read(araddr)
+        vthread.finish()
+
+    th = vthread.Thread(m, 'th_ctrl', clk, rst, ctrl)
+    fsm = th.start()
+
+    uut = m.Instance(led, 'uut',
+                     params=m.connect_params(led),
+                     ports=m.connect_ports(led))
+
+    #simulation.setup_waveform(m, uut)
+    simulation.setup_clock(m, clk, hperiod=5)
+    init = simulation.setup_reset(m, rst, m.make_reset(), period=100)
+
+    init.add(
+        Delay(1000000),
+        Systask('finish'),
+    )
+
+    return m
+
+
+def run(filename='tmp.v', simtype='iverilog', outputfile=None):
+
+    if outputfile is None:
+        outputfile = os.path.splitext(os.path.basename(__file__))[0] + '.out'
+
+    memimg_name = 'memimg_' + outputfile
+
+    test = mkTest(memimg_name=memimg_name)
+
+    if filename is not None:
+        test.to_verilog(filename)
+
+    sim = simulation.Simulator(test, sim=simtype)
+    rslt = sim.run(outputfile=outputfile)
+    lines = rslt.splitlines()
+    if simtype == 'verilator' and lines[-1].startswith('-'):
+        rslt = '\n'.join(lines[:-1])
+    return rslt
+
+
+if __name__ == '__main__':
+    rslt = run(filename='tmp.v')
+    print(rslt)

--- a/tests/extension/thread_/stream_linebuffer3d/Makefile
+++ b/tests/extension/thread_/stream_linebuffer3d/Makefile
@@ -1,0 +1,29 @@
+TARGET=$(shell ls *.py | grep -v test | grep -v parsetab.py)
+ARGS=
+
+PYTHON=python3
+#PYTHON=python
+#OPT=-m pdb
+#OPT=-m cProfile -s time
+#OPT=-m cProfile -o profile.rslt
+
+.PHONY: all
+all: test
+
+.PHONY: run
+run:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS)
+
+.PHONY: test
+test:
+	$(PYTHON) -m pytest -vv
+
+.PHONY: check
+check:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS) > tmp.v
+	iverilog -tnull -Wall tmp.v
+	rm -f tmp.v
+
+.PHONY: clean
+clean:
+	rm -rf *.pyc __pycache__ parsetab.py .cache *.out *.png *.dot tmp.v uut.vcd

--- a/tests/extension/thread_/stream_linebuffer3d/test_thread_stream_linebuffer3d.py
+++ b/tests/extension/thread_/stream_linebuffer3d/test_thread_stream_linebuffer3d.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import veriloggen
+import thread_stream_linebuffer3d
+
+
+def test(request):
+    veriloggen.reset()
+
+    simtype = request.config.getoption('--sim')
+
+    rslt = thread_stream_linebuffer3d.run(filename=None, simtype=simtype,
+                                    outputfile=os.path.splitext(os.path.basename(__file__))[0] + '.out')
+
+    verify_rslt = rslt.splitlines()[-1]
+    assert(verify_rslt == '# verify: PASSED')

--- a/tests/extension/thread_/stream_linebuffer3d/thread_stream_linebuffer3d.py
+++ b/tests/extension/thread_/stream_linebuffer3d/thread_stream_linebuffer3d.py
@@ -1,0 +1,190 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import sys
+import os
+import functools
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))))
+
+from veriloggen import *
+import veriloggen.thread as vthread
+import veriloggen.types.axi as axi
+
+
+def mkLed():
+    m = Module('blinkled')
+    clk = m.Input('CLK')
+    rst = m.Input('RST')
+
+    datawidth = 32
+    addrwidth = 10
+    saxi_length = 5
+    myaxi = vthread.AXIM(m, 'myaxi', clk, rst, datawidth)
+    saxi = vthread.AXISLiteRegister(m, 'saxi', clk, rst, datawidth=datawidth, length=saxi_length)
+    ram_src = vthread.RAM(m, 'ram_src', clk, rst, datawidth, addrwidth)
+    ram_dummy_src = vthread.RAM(m, 'ram_dummy_src', clk, rst, datawidth, addrwidth)
+    ram_dst = vthread.RAM(m, 'ram_dst', clk, rst, datawidth, addrwidth)
+
+    strm = vthread.Stream(m, 'mystream', clk, rst)
+    dummy_src = strm.source('dummy_src')
+    c = strm.Counter(initval=0, size=4)
+    x = strm.Counter(initval=0, size=8, enable=(c==3))
+    y = strm.Counter(initval=0, size=8, enable=((c==3) & (x==7)))
+    shift_cond = (x&1 == 0) & ((y&1) == 0)
+    rotate_cond1 = (((((x&1) == 0) & ((y&1) == 0)) == 0) & (((x&1) == 0) == 0))
+    rotate_cond2 = (((((x&1) == 0) & ((y&1) == 0)) == 0) & ((x&1) == 0))
+    read_cond = shift_cond
+    addrcounter = strm.Counter(initval=0, enable=read_cond)
+    src = strm.read_RAM('ram_src', addr=addrcounter, when=read_cond, datawidth=datawidth)
+    counter = strm.Counter(initval=0)
+    width = strm.constant('width')
+    height = strm.constant('height')
+    linebuf = strm.LineBuffer(shape=(1, 1, 1), memlens=[4, 13], head_initvals=[0, 0], tail_initvals=[3, 12], data=src, shift_cond=shift_cond, rotate_conds=[rotate_cond1, rotate_cond2])
+    dst = linebuf.get_window(0)
+    strm.sink(dst, 'dst')
+
+    def comp_stream(channel, width, height, offset):
+        strm.set_source('dummy_src', ram_dummy_src, offset, channel * width * height * 2 * 2)
+        strm.set_read_RAM('ram_src', ram_src)
+        strm.set_sink('dst', ram_dst, offset, channel * width * height * 2 * 2)
+        strm.set_constant('width', width)
+        strm.set_constant('height', height)
+        strm.run()
+        strm.join()
+
+    def comp_sequential(channel, width, height, roffset, woffset):
+        for yy in range(height*2):
+            for xx in range(width*2):
+                for c in range(channel):
+                    # f(c, x, y) = in(c, x/2, y/2);
+                    src_i = (xx//2) * channel + (yy//2) * width * channel + c
+                    dst_i = xx * channel + yy * width * 2 * channel + c
+                    val = ram_src.read(roffset + src_i)
+                    ram_dst.write(woffset + dst_i, val)
+            
+    def check(offset_stream, offset_seq, size):
+        all_ok = True
+        for i in range(size):
+            st = ram_dst.read(offset_stream + i)
+            sq = ram_dst.read(offset_seq + i)
+            if vthread.verilog.NotEql(st, sq):
+                all_ok = False
+            # print(st, sq)
+        if all_ok:
+            print('# verify: PASSED')
+        else:
+            print('# verify: FAILED')
+
+    def comp():
+        saxi.write(addr=1, value=0)
+        saxi.wait_flag(0, value=1, resetvalue=0)
+        channel = saxi.read(2)
+        width = saxi.read(3)
+        height = saxi.read(4)
+        insize = channel * width * height
+        outsize = channel * width * 2 * height * 2
+
+        roffset = 0
+        woffset = 0
+        myaxi.dma_read(ram_src, roffset, 0, insize)
+        comp_stream(channel, width, height, roffset)
+        myaxi.dma_write(ram_dst, woffset, 1024, outsize)
+
+        roffset = insize
+        woffset = outsize
+        myaxi.dma_read(ram_src, roffset, 0, insize)
+        comp_sequential(channel, width, height, roffset, woffset)
+        myaxi.dma_write(ram_dst, woffset, 2*1024, outsize)
+
+        check(0, woffset, outsize)
+        saxi.write(addr=1, value=1)
+
+    th = vthread.Thread(m, 'th_comp', clk, rst, comp)
+    fsm = th.start()
+    strm.draw_graph(filename='strm.png')
+    return m
+
+
+def mkTest(memimg_name=None):
+    m = Module('test')
+
+    # target instance
+    led = mkLed()
+
+    # copy paras and ports
+    params = m.copy_params(led)
+    ports = m.copy_sim_ports(led)
+
+    clk = ports['CLK']
+    rst = ports['RST']
+
+    memory = axi.AxiMemoryModel(m, 'memory', clk, rst, memimg_name=memimg_name)
+    memory.connect(ports, 'myaxi')
+    maxi = vthread.AXIMLite(m, 'maxi', clk, rst, noio=True)
+    maxi.connect(ports, 'saxi')
+
+    def ctrl():
+        channel, width, height = [4, 4, 4]
+
+        awaddr = 2 * 4
+        maxi.write(awaddr, channel)
+
+        awaddr = 3 * 4
+        maxi.write(awaddr, width)
+
+        awaddr = 4 * 4
+        maxi.write(awaddr, height)
+
+        awaddr = 0 * 4
+        maxi.write(awaddr, 1)
+
+        araddr = 1 * 4
+        v = maxi.read(araddr)
+        while v == 0:
+            v = maxi.read(araddr)
+        vthread.finish()
+
+    th = vthread.Thread(m, 'th_ctrl', clk, rst, ctrl)
+    fsm = th.start()
+
+    uut = m.Instance(led, 'uut',
+                     params=m.connect_params(led),
+                     ports=m.connect_ports(led))
+
+    #simulation.setup_waveform(m, uut)
+    simulation.setup_clock(m, clk, hperiod=5)
+    init = simulation.setup_reset(m, rst, m.make_reset(), period=100)
+
+    init.add(
+        Delay(1000000),
+        Systask('finish'),
+    )
+
+    return m
+
+
+def run(filename='tmp.v', simtype='iverilog', outputfile=None):
+
+    if outputfile is None:
+        outputfile = os.path.splitext(os.path.basename(__file__))[0] + '.out'
+
+    memimg_name = 'memimg_' + outputfile
+
+    test = mkTest(memimg_name=memimg_name)
+
+    if filename is not None:
+        test.to_verilog(filename)
+
+    sim = simulation.Simulator(test, sim=simtype)
+    rslt = sim.run(outputfile=outputfile)
+    lines = rslt.splitlines()
+    if simtype == 'verilator' and lines[-1].startswith('-'):
+        rslt = '\n'.join(lines[:-1])
+    return rslt
+
+
+if __name__ == '__main__':
+    rslt = run(filename='tmp.v')
+    print(rslt)


### PR DESCRIPTION
## stypes.LineBuffer
```python
LineBuffer(shape, memlens, data, head_initvals, tail_initvals, shift_cond, rotate_conds)
```
The input arguments of stypes.LineBuffer is as the following.
- shape: size of each dimension of the line buffer `(d_0, d_1, ... d_{n-1})`
- memlens: length of shift memory of each dimension `(s_1, ... s_{n-1})`
- data: source input value of the linebuffer
- head_initvals: lists of read index value of shift memory of each dimension  `(h_1, ... h_{n-1})`
- tail_initvals: lists of writeindex value of shift memory of each dimension   `(t_1, ... t_{n-1})`
- shift_cond: condition of linebuffer shift operation
- rotate_conds: lists of the condition of linebuffer rotate operation for each dimesnsion

Linebuffer consists of window registers and shift memories, and its inner status is updated by shift or rotate operation.
The rotate operation of linebuffer is used in cases such as upsampling, and it enables more efficient resource use than increasing the size of the line buffer and realizing it only by shifting operations.
The n-dimension linebuffer (`shape=(d_0, d_1..d_{n-1})`) has `d_0*d_1...*d_{n-1}` window registers, and their indices are represented as `(0,0,... 0)...(d_0-1, d_1-1,... d_{n-1}-1)`.  
Linebuffer has n-1 different dimensional shift memory from 1 to n-1, and the number of k-dimensional linebuffer is `d_k*...*d{n-1}`, and their indices are represented as `(0, ...0) ... (d_k-1, ... d{n-1}-1)`.  

`head/tail` are defined for each shift memory dimension. Shift memory is realized by 2-port BRAM, and reads address `head` and writes address `tail`. The `head/tail` value are incremented when the shift memory of its dimension is operated by shift/rotate operation, and reset to zero when its value is over than the `memlen` value of its dimension.
  
The following figure represents `shape = (1,3,3)` linebuffer and its shift/rotate(dim=1,2) operation.

![rotate3d_pr](https://user-images.githubusercontent.com/7277966/98264960-d35f6a80-1fcb-11eb-8060-d47c30fcda6a.png)

Shift operation writes `data` value to the top window register, and the value of window registers and shift memory are shifted.  
N-dimensional linebuffer has n-1 kind rotate operations, and the head values of shift memory of the specified dimension are written back to the window registers. For example, in k-dimensional rotate operation, the head value of shift memory with index `(i_0 ... i_{n-1-k})` is written back to the window register with index`(d_0-1, i_0 ... i_{n-1-k})`.  
On k-dimensional rotate operation, shift memories of k+1 dimension or more are not updated, and shift memories of k-1 or less and the rest window registers are updated as well as the shift operation.  

`LineBuffer.get_window(index)` method can be used to access the window registers of the linebuffer. The input argument `index` is the tuple of window register index or the _int_ scalar value of the dictionary order of the window register.
 
## implementation
Shift/Rotate operation are performed in 2 clock cycles (pipeline stages). In the first cycle, the head values of all shift memories are read and its value is used for updating window registers and shift memory in the shift/rotate operation in the second cycle.  
The shift / rotate operation can be driven every clock in pipeline, but **the RAW distance of the shift memory (tail - head) must be 2 or more.**
The following figures show the scheduling and the block diagram of the `shape=(3,3)` linebuffer as example.
<img src="https://user-images.githubusercontent.com/7277966/98272146-1cb3b800-1fd4-11eb-89f3-bb37d969684e.png" width="50%">
<img src="https://user-images.githubusercontent.com/7277966/98272750-c5621780-1fd4-11eb-80c3-3416f9f65c59.png" width="60%">

## testcase
As the example use of stypes.LineBuffer, I add the `stream_linebuffer2d`, `stream_linebuffer2d_2`, `stream_linebuffer3d` test.
- stream_linebuffer2d    : upsampling test of 2D image from (4,4) to (8,8)
- stream_linebuffer2d_2 : linebuffer test to drive shift operation and rotate operation every clock
- stream_linebuffer3d  : upsampling test of 3D image from (4,4,4) to (4,8,8)




