### PR TITLE
Support for binary operations with _Numeric class in the right term

### DIFF
--- a/tests/core/op_reverse/Makefile
+++ b/tests/core/op_reverse/Makefile
@@ -1,0 +1,29 @@
+TARGET=$(shell ls *.py | grep -v test | grep -v parsetab.py)
+ARGS=
+
+PYTHON=python3
+#PYTHON=python
+#OPT=-m pdb
+#OPT=-m cProfile -s time
+#OPT=-m cProfile -o profile.rslt
+
+.PHONY: all
+all: test
+
+.PHONY: run
+run:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS)
+
+.PHONY: test
+test:
+	$(PYTHON) -m pytest -vv
+
+.PHONY: check
+check:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS) > tmp.v
+	iverilog -tnull -Wall tmp.v
+	rm -f tmp.v
+
+.PHONY: clean
+clean:
+	rm -rf *.pyc __pycache__ parsetab.py .cache *.out *.png *.dot tmp.v uut.vcd

--- a/tests/core/op_reverse/op_reverse.py
+++ b/tests/core/op_reverse/op_reverse.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import sys
+import os
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from veriloggen import *
+
+
+def mkLed():
+    m = Module('blinkled')
+    width = m.Parameter('WIDTH', 8)
+    a = m.Input('A', 32)
+    b = m.Output('B', width)
+    
+    b.assign(a[32-width:32])
+
+    return m
+
+if __name__ == '__main__':
+    led = mkLed()
+    verilog = led.to_verilog()
+    print(verilog)

--- a/tests/core/op_reverse/test_op_reverse.py
+++ b/tests/core/op_reverse/test_op_reverse.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import veriloggen
+import op_reverse
+
+expected_verilog = """
+module blinkled #
+(
+  parameter WIDTH = 8
+)
+(
+  input [32-1:0] A,
+  output [WIDTH-1:0] B
+);
+
+  assign B = A[31:32-WIDTH];
+
+endmodule
+"""
+
+def test():
+    veriloggen.reset()
+    test_module = op_reverse.mkLed()
+    code = test_module.to_verilog()
+
+    from pyverilog.vparser.parser import VerilogParser
+    from pyverilog.ast_code_generator.codegen import ASTCodeGenerator
+    parser = VerilogParser()
+    expected_ast = parser.parse(expected_verilog)
+    codegen = ASTCodeGenerator()
+    expected_code = codegen.visit(expected_ast)
+
+    assert(expected_code == code)

--- a/veriloggen/core/vtypes.py
+++ b/veriloggen/core/vtypes.py
@@ -383,6 +383,45 @@ class _Numeric(VeriloggenNode):
     def __rshift__(self, r):
         return Srl(self, r)
 
+    def __radd__(self, l):
+        return Plus(l, self)
+
+    def __rsub__(self, l):
+        return Minus(l, self)
+
+    def __rpow__(self, l):
+        return Power(l, self)
+
+    def __rmul__(self, l):
+        return Times(l, self)
+
+    def __rdiv__(self, l):
+        return Divide(l, self)
+
+    def __rtruediv__(self, l):
+        return Divide(l, self)
+
+    def __rfloordiv__(self, l):
+        return Divide(l, self)
+
+    def __rmod__(self, l):
+        return Mod(l, self)
+
+    def __rand__(self, l):
+        return And(l, self)
+
+    def __ror__(self, l):
+        return Or(l, self)
+
+    def __rxor__(self, l):
+        return Xor(l, self)
+
+    def __rlshift__(self, l):
+        return Sll(l, self)
+
+    def __rrshift__(self, l):
+        return Srl(l, self)
+
     def __neg__(self):
         return Uminus(self)
 


### PR DESCRIPTION
When trying to perform a binary operation on an int variable and a Parameter variable:
```Python3
m = Module('blinkled')
width = m.Parameter('WIDTH', 8)
a = m.Input('A', 32)
b = m.Output('B', width)
b.assign(a[32-width:32])
```
And I expected B to be assigned the following:
```Verilog
assign B = A[31:32-WIDTH];
```
But I got the following error.
```
TypeError: unsupported operand type(s) for -: 'int' and 'Parameter'
```

So I added support for binary operations with _Numeric class in the right term.