### PR TITLE
fix and update thread_matmul_ext_onchip_ram

### DIFF
--- a/examples/thread_matmul_ext_onchip_ram/thread_matmul_ext_onchip_ram.py
+++ b/examples/thread_matmul_ext_onchip_ram/thread_matmul_ext_onchip_ram.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import sys
 import os
 import numpy as np
+import math
 
 # the next line can be removed after installation
 sys.path.insert(0, os.path.dirname(os.path.dirname(
@@ -12,13 +13,23 @@ from veriloggen import *
 import veriloggen.thread as vthread
 import veriloggen.types.axi as axi
 
-datawidth = 8
+mem_datawidth = 8
+datawidth = 16
 addrwidth = 8
 
-matrix_size = 8
+matrix_size = 10
+
+num_pack = math.ceil(datawidth / mem_datawidth)
+addr_pack = math.ceil((addrwidth + math.ceil(np.log2(datawidth / mem_datawidth)))
+                       / mem_datawidth)
+
+matrix_size_addr = 0
+a_offset_addr = 4
+b_offset_addr = 8
+c_offset_addr = 12
 a_offset = 16
-b_offset = a_offset + matrix_size * matrix_size
-c_offset = b_offset + matrix_size * matrix_size
+b_offset = a_offset + matrix_size * matrix_size * num_pack
+c_offset = b_offset + matrix_size * matrix_size * num_pack
 
 
 def mkLed():
@@ -28,7 +39,8 @@ def mkLed():
     start = m.Input('start')
     busy = m.OutputReg('busy', initval=0)
 
-    ram = vthread.ExtRAM(m, 'ram', clk, rst, datawidth, addrwidth)
+    ram = vthread.ExtRAM(m, 'ram', clk, rst, mem_datawidth, 
+                         addrwidth + math.ceil(np.log2(datawidth / mem_datawidth)))
 
     def matmul():
         while True:
@@ -46,27 +58,31 @@ def mkLed():
         busy.value = 1
 
     def read_matrix_size():
-        size0 = ram.read(0)
-        size1 = ram.read(1)
-        size = (size1 << 8) | size0
+        size = 0
+        for i in range(addr_pack):
+            size |= ((ram.read(matrix_size_addr + i) & ((1 << mem_datawidth) - 1))
+                     << (mem_datawidth * i))
         return size
 
     def read_matrix_a_offset():
-        offset0 = ram.read(4) & 0xff
-        offset1 = ram.read(5) & 0xff
-        offset = (offset1 << 8) | offset0
+        offset = 0
+        for i in range(addr_pack):
+            offset |= ((ram.read(a_offset_addr + i) & ((1 << mem_datawidth) - 1))
+                       << (mem_datawidth * i))
         return offset
 
     def read_matrix_b_offset():
-        offset0 = ram.read(8) & 0xff
-        offset1 = ram.read(9) & 0xff
-        offset = (offset1 << 8) | offset0
+        offset = 0
+        for i in range(addr_pack):
+            offset |= ((ram.read(b_offset_addr + i) & ((1 << mem_datawidth) - 1))
+                       << (mem_datawidth * i))
         return offset
 
     def read_matrix_c_offset():
-        offset0 = ram.read(12) & 0xff
-        offset1 = ram.read(13) & 0xff
-        offset = (offset1 << 8) | offset0
+        offset = 0
+        for i in range(addr_pack):
+            offset |= ((ram.read(c_offset_addr + i) & ((1 << mem_datawidth) - 1))
+                       << (mem_datawidth * i))
         return offset
 
     def comp(matrix_size, a_offset, b_offset, c_offset):
@@ -77,15 +93,24 @@ def mkLed():
             for j in range(matrix_size):
                 sum = 0
                 for k in range(matrix_size):
-                    x = ram.read(a_addr + k)
-                    y = ram.read(b_addr + k)
+                    x = int(0, base=2)
+                    y = 0
+                    for l in range(num_pack):
+                        x |= ((ram.read(a_addr + k * num_pack + l) 
+                               & ((1 << mem_datawidth) - 1))
+                              << (mem_datawidth * l))
+                        y |= ((ram.read(b_addr + k * num_pack + l) 
+                               & ((1 << mem_datawidth) - 1)) 
+                              << (mem_datawidth * l))
                     sum += x * y
-                ram.write(c_addr + j, sum)
+                for l in range(num_pack):
+                    ram.write(c_addr + j * num_pack + l,
+                              (sum >> (mem_datawidth * l)) & (1<<mem_datawidth)-1)
 
-                b_addr += matrix_size * (datawidth // 8)
+                b_addr += matrix_size * num_pack
 
-            a_addr += matrix_size * (datawidth // 8)
-            c_addr += matrix_size * (datawidth // 8)
+            a_addr += matrix_size * num_pack
+            c_addr += matrix_size * num_pack
 
     def done():
         busy.value = 0
@@ -128,13 +153,11 @@ def mkTest(memimg_name=None):
                 b[y][x] = 0
 
     a_addr = a_offset
-    size_a = n_a * datawidth // 8
     b_addr = b_offset
-    size_b = n_b * datawidth // 8
 
-    mem = np.zeros([2 ** addrwidth * (8 // datawidth)], dtype=np.int64)
-    axi.set_memory(mem, a, datawidth, datawidth, a_addr)
-    axi.set_memory(mem, b, datawidth, datawidth, b_addr)
+    mem = np.zeros([(2 ** addrwidth) * num_pack], dtype=np.int64)
+    axi.set_memory(mem, a, mem_datawidth, datawidth, a_addr)
+    axi.set_memory(mem, b, mem_datawidth, datawidth, b_addr)
 
     led = mkLed()
 
@@ -149,7 +172,8 @@ def mkTest(memimg_name=None):
 
     start.initval = 0
 
-    memory = vthread.RAM(m, 'memory', clk, rst, datawidth, addrwidth,
+    memory = vthread.RAM(m, 'memory', clk, rst, mem_datawidth, 
+                         addrwidth + math.ceil(np.log2(datawidth / mem_datawidth)),
                          numports=2, initvals=mem.tolist())
     memory.connect_rtl(0, ports['ram_0_addr'], ports['ram_0_wdata'],
                        ports['ram_0_wenable'], ports['ram_0_rdata'],
@@ -166,45 +190,33 @@ def mkTest(memimg_name=None):
         for i in range(100):
             pass
 
-        awaddr = 0
-        v = (matrix_size & 0xff)
-        print('# matrix_size[7:0] = %d' % v)
-        memory.write(awaddr, v, port=1)
+        for i in range(addr_pack):
+            awaddr = matrix_size_addr + i
+            v = (matrix_size >> (mem_datawidth * i)) & ((1 << mem_datawidth) - 1)
+            print('# matrix_size[%d:%d] = %d' % 
+                  (mem_datawidth * (i+1) - 1, mem_datawidth * i, v))
+            memory.write(awaddr, v, port=1)
 
-        awaddr = 1
-        v = ((matrix_size >> 8) & 0xff)
-        print('# matrix_size[15:8] = %d' % v)
-        memory.write(awaddr, v, port=1)
+        for i in range(addr_pack):
+            awaddr = a_offset_addr + i
+            v = (a_offset >> (mem_datawidth * i)) & ((1 << mem_datawidth) - 1)
+            print('# a_offset[%d:%d] = %d' % 
+                  (mem_datawidth * (i+1) - 1, mem_datawidth * i, v))
+            memory.write(awaddr, v, port=1)
 
-        awaddr = 4
-        v = (a_offset & 0xff)
-        print('# a_offset[7:0] = %d' % v)
-        memory.write(awaddr, v, port=1)
+        for i in range(addr_pack):
+            awaddr = b_offset_addr + i
+            v = (b_offset >> (mem_datawidth * i)) & ((1 << mem_datawidth) - 1)
+            print('# b_offset[%d:%d] = %d' % 
+                  (mem_datawidth * (i+1) - 1, mem_datawidth * i, v))
+            memory.write(awaddr, v, port=1)
 
-        awaddr = 5
-        v = ((a_offset >> 8) & 0xff)
-        print('# a_offset[15:8] = %d' % v)
-        memory.write(awaddr, v, port=1)
-
-        awaddr = 8
-        v = (b_offset & 0xff)
-        print('# b_offset[7:0] = %d' % v)
-        memory.write(awaddr, v, port=1)
-
-        awaddr = 9
-        v = ((b_offset >> 8) & 0xff)
-        print('# b_offset[15:8] = %d' % v)
-        memory.write(awaddr, v, port=1)
-
-        awaddr = 12
-        v = (c_offset & 0xff)
-        print('# c_offset[7:0] = %d' % v)
-        memory.write(awaddr, v, port=1)
-
-        awaddr = 13
-        v = ((c_offset >> 8) & 0xff)
-        print('# c_offset[15:8] = %d' % v)
-        memory.write(awaddr, v, port=1)
+        for i in range(addr_pack):
+            awaddr = c_offset_addr + i
+            v = (c_offset >> (mem_datawidth * i)) & ((1 << mem_datawidth) - 1)
+            print('# c_offset[%d:%d] = %d' % 
+                  (mem_datawidth * (i+1) - 1, mem_datawidth * i, v))
+            memory.write(awaddr, v, port=1)
 
         start_time = counter
         print('# start time = %d' % start_time)
@@ -227,14 +239,19 @@ def mkTest(memimg_name=None):
         all_ok = True
         for y in range(matrix_size):
             for x in range(matrix_size):
-                v = memory.read(
-                    c_offset + (y * matrix_size + x) * datawidth // 8, port=1)
+                v = 0
+                v_addr = c_offset + (y * matrix_size + x) * num_pack
+                for l in range(num_pack):
+                    v |= memory.read(v_addr + l, port=1) << (mem_datawidth * l)
+                    v |= ((memory.read(v_addr + l, port=1) 
+                           & ((1 << mem_datawidth) - 1))
+                          << (mem_datawidth * l))
                 if y == x and vthread.verilog.NotEql(v, (y + 1) * 2):
                     all_ok = False
-                    print("NG [%d,%d] = %d" % (y, x, v))
+                    print("NG [%d,%d] = %d (expected: %d)" % (y, x, v, (y + 1) * 2))
                 if y != x and vthread.verilog.NotEql(v, 0):
                     all_ok = False
-                    print("NG [%d,%d] = %d" % (y, x, v))
+                    print("NG [%d,%d] = %d (expected: %d)" % (y, x, v, 0))
 
         if all_ok:
             print('# verify: PASSED')


### PR DESCRIPTION

# summary

Fixed a bug of `examples/thread_matmul_ext_onchip_ram.py`, at the same time introducing reconfigurability.

# detail

This example originally had the [below code](https://github.com/PyHDI/veriloggen/blob/e0fd2fededce801df4ed1a27610c1153b28d7603/examples/thread_matmul_ext_onchip_ram/thread_matmul_ext_onchip_ram.py#L135), which led to incorrect verilog output when `datawidth != 8`.
```python
    mem = np.zeros([2 ** addrwidth * (8 // datawidth)], dtype=np.int64)
```

This part seems to have derived from [code](https://github.com/PyHDI/veriloggen/blob/e0fd2fededce801df4ed1a27610c1153b28d7603/examples/thread_matmul/thread_matmul.py#L115) in `examples/thread_matmul.py`, whose intention is utterly different.
I have fixed this issue, and brought reconfigurability to the example.
It now works with arbitrary values of parameters!

