### PR TITLE
Add f-strings support in `print()` within threads

### DIFF
--- a/tests/extension/thread_/print_fstrings/Makefile
+++ b/tests/extension/thread_/print_fstrings/Makefile
@@ -1,0 +1,29 @@
+TARGET=$(shell ls *.py | grep -v test | grep -v parsetab.py)
+ARGS=
+
+PYTHON=python3
+#PYTHON=python
+#OPT=-m pdb
+#OPT=-m cProfile -s time
+#OPT=-m cProfile -o profile.rslt
+
+.PHONY: all
+all: test
+
+.PHONY: run
+run:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS)
+
+.PHONY: test
+test:
+	$(PYTHON) -m pytest -vv
+
+.PHONY: check
+check:
+	$(PYTHON) $(OPT) $(TARGET) $(ARGS) > tmp.v
+	iverilog -tnull -Wall tmp.v
+	rm -f tmp.v
+
+.PHONY: clean
+clean:
+	rm -rf *.pyc __pycache__ parsetab.py .cache *.out *.png *.dot tmp.v *.vcd

--- a/tests/extension/thread_/print_fstrings/test_thread_print_fstrings.py
+++ b/tests/extension/thread_/print_fstrings/test_thread_print_fstrings.py
@@ -1,0 +1,148 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import veriloggen
+import thread_print_fstrings
+
+expected_verilog = """
+module test
+(
+
+);
+
+  reg CLK;
+  reg RST;
+  wire [8-1:0] LED;
+
+  blinkled
+  uut
+  (
+    .CLK(CLK),
+    .RST(RST),
+    .LED(LED)
+  );
+
+
+  initial begin
+    CLK = 0;
+    forever begin
+      #5 CLK = !CLK;
+    end
+  end
+
+
+  initial begin
+    RST = 0;
+    #100;
+    RST = 1;
+    #100;
+    RST = 0;
+    #50000;
+    $finish;
+  end
+
+
+endmodule
+
+
+
+module blinkled
+(
+  input CLK,
+  input RST,
+  output reg [8-1:0] LED
+);
+
+  reg [10-1:0] CNT;
+  reg [32-1:0] th_blink;
+  localparam th_blink_init = 0;
+  localparam th_blink_1 = 1;
+  localparam th_blink_2 = 2;
+  localparam th_blink_3 = 3;
+  localparam th_blink_4 = 4;
+  localparam th_blink_5 = 5;
+  localparam th_blink_6 = 6;
+  localparam th_blink_7 = 7;
+  localparam th_blink_8 = 8;
+  localparam th_blink_9 = 9;
+  localparam th_blink_10 = 10;
+  localparam th_blink_11 = 11;
+
+  always @(posedge CLK) begin
+    if(RST) begin
+      th_blink <= th_blink_init;
+      LED <= 0;
+      CNT <= 0;
+    end else begin
+      case(th_blink)
+        th_blink_init: begin
+          th_blink <= th_blink_1;
+        end
+        th_blink_1: begin
+          $display("Hello, world!");
+          th_blink <= th_blink_2;
+        end
+        th_blink_2: begin
+          if(1) begin
+            th_blink <= th_blink_3;
+          end else begin
+            th_blink <= th_blink_11;
+          end
+        end
+        th_blink_3: begin
+          LED <= LED + 1;
+          th_blink <= th_blink_4;
+        end
+        th_blink_4: begin
+          CNT <= CNT + 3;
+          th_blink <= th_blink_5;
+        end
+        th_blink_5: begin
+          if(LED % 70 == 0) begin
+            th_blink <= th_blink_6;
+          end else begin
+            th_blink <= th_blink_10;
+          end
+        end
+        th_blink_6: begin
+          $display("");
+          th_blink <= th_blink_7;
+        end
+        th_blink_7: begin
+          $display("led = %0d (%b)", LED, LED);
+          th_blink <= th_blink_8;
+        end
+        th_blink_8: begin
+          $display("cnt = %0d (%b)", CNT, CNT);
+          th_blink <= th_blink_9;
+        end
+        th_blink_9: begin
+          $display("clk + led = %d", (CLK + LED));
+          th_blink <= th_blink_10;
+        end
+        th_blink_10: begin
+          th_blink <= th_blink_2;
+        end
+      endcase
+    end
+  end
+
+
+endmodule
+"""
+
+
+def test():
+    veriloggen.reset()
+    test_module = thread_print_fstrings.mkTest()
+    code = test_module.to_verilog()
+
+    from pyverilog.vparser.parser import VerilogParser
+    from pyverilog.ast_code_generator.codegen import ASTCodeGenerator
+    parser = VerilogParser()
+    expected_ast = parser.parse(expected_verilog)
+    codegen = ASTCodeGenerator()
+    expected_code = codegen.visit(expected_ast)
+
+    assert(expected_code == code)
+
+test()

--- a/tests/extension/thread_/print_fstrings/test_thread_print_fstrings.py
+++ b/tests/extension/thread_/print_fstrings/test_thread_print_fstrings.py
@@ -116,7 +116,7 @@ module blinkled
           th_blink <= th_blink_9;
         end
         th_blink_9: begin
-          $display("clk + led = %d", (CLK + LED));
+          $display("cnt + led = %d", (CNT + LED));
           th_blink <= th_blink_10;
         end
         th_blink_10: begin

--- a/tests/extension/thread_/print_fstrings/thread_print_fstrings.py
+++ b/tests/extension/thread_/print_fstrings/thread_print_fstrings.py
@@ -27,7 +27,7 @@ def mkLed():
                 print()
                 print('led = %0d (%b)' % (led, led))
                 print(f'{cnt = :0d} ({cnt:b})')
-                print(f'clk + led = {clk + led}')
+                print(f'cnt + led = {cnt + led}')
 
     th = vthread.Thread(m, 'th_blink', clk, rst, blink)
     fsm = th.start()

--- a/tests/extension/thread_/print_fstrings/thread_print_fstrings.py
+++ b/tests/extension/thread_/print_fstrings/thread_print_fstrings.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import sys
+import os
+
+# the next line can be removed after installation
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))))
+
+from veriloggen import *
+import veriloggen.thread as vthread
+
+
+def mkLed():
+    m = Module('blinkled')
+    clk = m.Input('CLK')
+    rst = m.Input('RST')
+    led = m.OutputReg('LED', 8, initval=0)
+    cnt = m.Reg('CNT', 10, initval=0)
+
+    def blink():
+        print('Hello, world!')
+        while True:
+            led.value += 1
+            cnt.value += 3
+            if led.value % 70 == 0:
+                print()
+                print('led = %0d (%b)' % (led, led))
+                print(f'{cnt = :0d} ({cnt:b})')
+                print(f'clk + led = {clk + led}')
+
+    th = vthread.Thread(m, 'th_blink', clk, rst, blink)
+    fsm = th.start()
+
+    return m
+
+
+def mkTest():
+    m = Module('test')
+
+    # target instance
+    led = mkLed()
+
+    # copy paras and ports
+    params = m.copy_params(led)
+    ports = m.copy_sim_ports(led)
+
+    clk = ports['CLK']
+    rst = ports['RST']
+
+    uut = m.Instance(led, 'uut',
+                     params=m.connect_params(led),
+                     ports=m.connect_ports(led))
+
+    # vcd_name = os.path.splitext(os.path.basename(__file__))[0] + '.vcd'
+    # simulation.setup_waveform(m, uut, dumpfile=vcd_name)
+    simulation.setup_clock(m, clk, hperiod=5)
+    init = simulation.setup_reset(m, rst, m.make_reset(), period=100)
+
+    init.add(
+        Delay(50000),
+        Systask('finish'),
+    )
+
+    return m
+
+
+if __name__ == '__main__':
+    test = mkTest()
+    verilog = test.to_verilog('tmp.v')
+    print(verilog)
+
+    sim = simulation.Simulator(test)
+    rslt = sim.run()
+    print(rslt)


### PR DESCRIPTION
# Add f-strings support in `print()` within threads

## Background

In Python 3.6, a brand new way of formatting string called _Formatted String Literals_ a.k.a. _f-strings_ was introduced.
This feature impoved the printing experience of Python developers all around the globe.

However, Veriloggen has been failing to fully take advantage of this new coding style.
Veriloggen interprets the built-in `print()` function as `$display()`, within functions that are passed to `Thread` class as its 5th argument (`targ`). As the backend of Veriloggen processes such `print()` functions in its own way, using f-strings in this situation has raised `Error`s unlike `print()` in other contexts.

## Implementation

To address the issue, I have enhanced Veriloggen by modifying `veriloggen/thread/compiler.py`.
In `CompileVisitor._call_Name_print()`, a new `elif` branch is added where f-strings are processed. Note that the f-strings feature was introduced in Python 3.6 and the corresponding `ast` classes are available only after this version of Python.
Function `CompileVisitor._print_f_strings()` is added for simpler implementation. Although it does not guarantee if a simulator actually accepts the final contents of the `$display()` or not, at least it eliminates nested f-strings as they are likely to be unnecessary.

## Test

I added a new test case, `tests/extension/thread_/print_f_strings`, based on `tests/extension/thread_/hello`.